### PR TITLE
Set cause when throwing due to init failure

### DIFF
--- a/java/org/apache/catalina/core/StandardService.java
+++ b/java/org/apache/catalina/core/StandardService.java
@@ -556,7 +556,7 @@ public class StandardService extends LifecycleMBeanBase implements Service {
                     log.error(message, e);
 
                     if (Boolean.getBoolean("org.apache.catalina.startup.EXIT_ON_INIT_FAILURE"))
-                        throw new LifecycleException(message);
+                        throw new LifecycleException(message, e);
                 }
             }
         }


### PR DESCRIPTION
Without the cause it is difficult to find out why initialization failed.

For example, a `java.net.BindException` and its message "Address already in use" is only logged, but otherwise lost.